### PR TITLE
fix use of undefined variable $summary in field formatter plugin

### DIFF
--- a/wetkit_widgets.plugins.inc
+++ b/wetkit_widgets.plugins.inc
@@ -164,6 +164,7 @@ function wetkit_widgets_field_formatter_info() {
 function wetkit_widgets_field_formatter_settings_summary($field, $instance, $view_mode) {
   $display = $instance['display'][$view_mode];
   $settings = $display['settings'];
+  $summary = "";
 
   if ($display['type'] == 'wetkit_widgets_lightbox') {
     // Destination image style.


### PR DESCRIPTION
Intialized a $summary variable so that it doesn't throw php notice:

`Notice: Undefined variable: summary in wetkit_widgets_field_formatter_settings_summary() (line 172 of /data/www/wet/profiles/wetkit/modules/custom/wetkit_widgets/wetkit_widgets.plugins.inc).`

Offending code:
`$summary .= "Destination image style: {$value}<br />";`
